### PR TITLE
Run integration specs under Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:precise
+
+# Set DEBIAN_FRONTEND to non-interactive to avoid useless warnings
+ENV DEBIAN_FRONTEND noninteractive
+
+# Update apt sources
+RUN apt-get update
+
+# Support adding PPAs
+RUN apt-get install -y python-software-properties
+
+# Install git
+RUN add-apt-repository -y ppa:git-core/ppa && \
+    apt-get update && \
+    apt-get install -y git
+
+# Install Go
+RUN add-apt-repository -y ppa:tsuru/golang && \
+    apt-get update && \
+    apt-get install -y golang
+
+# Install Ruby
+RUN apt-get install -y ruby1.9.3
+
+# Set the GOPATH
+ENV GOPATH /go
+
+# Install etcd v0.3.0
+RUN apt-get install -y wget && \
+    wget -O - -q "https://github.com/coreos/etcd/releases/download/v0.3.0/etcd-v0.3.0-linux-amd64.tar.gz" | \
+      tar xz --strip-components=1 -C /usr/local/bin
+
+# Install godep (requires mercurial)
+RUN apt-get install -y mercurial && \
+    go get github.com/kr/godep
+
+# Clone and build discoverd
+RUN git clone -b master https://github.com/flynn/discoverd.git /go/src/github.com/flynn/discoverd && \
+    cd /go/src/github.com/flynn/discoverd && \
+    /go/bin/godep go install
+
+# Add discoverd-ruby
+ADD . /discoverd-ruby
+
+# Bundle the gems (needs build tools)
+RUN apt-get install -y build-essential && \
+    gem install --no-ri --no-rdoc bundler && \
+    bundle install --gemfile /discoverd-ruby/Gemfile
+
+# Run etcd, discoverd then the integration tests
+CMD bash -c "/usr/local/bin/etcd >/dev/null &" && \
+    bash -c "/go/bin/discoverd >/dev/null &" && \
+    bash -c "cd /discoverd-ruby && bundle exec ruby -Ilib:test test/integration/test_*.rb"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -46,8 +46,3 @@ ADD . /discoverd-ruby
 RUN apt-get install -y build-essential && \
     gem install --no-ri --no-rdoc bundler && \
     bundle install --gemfile /discoverd-ruby/Gemfile
-
-# Run etcd, discoverd then the integration tests
-CMD bash -c "/usr/local/bin/etcd >/dev/null &" && \
-    bash -c "/go/bin/discoverd >/dev/null &" && \
-    bash -c "cd /discoverd-ruby && bundle exec ruby -Ilib:test test/integration/test_*.rb"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM discoverd-ruby-base
+
+# Add discoverd-ruby
+ADD . /discoverd-ruby
+
+# Run etcd, discoverd then the integration tests
+CMD bash -c "/usr/local/bin/etcd >/dev/null &" && \
+    bash -c "/go/bin/discoverd >/dev/null &" && \
+    bash -c "cd /discoverd-ruby && bundle exec ruby -Ilib:test test/integration/test_*.rb"

--- a/Rakefile
+++ b/Rakefile
@@ -7,16 +7,48 @@ namespace :test do
   end
 
   desc "Build the Docker image for running tests"
-  task :build_image => :docker do
-    system "docker build -rm=true -t discoverd-ruby-test ."
+  task :build_image => [:docker, "tmp/.build_base_image", :build_test_image]
+
+  # This task builds the base Docker image which has etcd, discoverd & gem dependencies.
+  #
+  # We use a file task as we only want to rebuild if the base dependencies change (so we
+  # don't have to install those dependencies every time we run the tests)
+  BASE_IMAGE_FILE_DEPENDENCIES = %w(
+    Dockerfile.base
+    Gemfile
+    Gemfile.lock
+    discover.gemspec
+  )
+  file "tmp/.build_base_image" => BASE_IMAGE_FILE_DEPENDENCIES do
+    FileUtils.ln_sf "Dockerfile.base", "Dockerfile"
+
+    unless system "docker build -rm=true -t discoverd-ruby-base ."
+      fail "failed to build the test Docker image, exiting"
+    end
+
+    FileUtils.touch "tmp/.build_base_image"
+  end
+
+  # The test image gets rebuilt every time we run the tests to ensure
+  # we are testing the correct code
+  task :build_test_image do
+    FileUtils.ln_sf "Dockerfile.test", "Dockerfile"
+
+    unless system "docker build -rm=true -t discoverd-ruby-test ."
+      fail "failed to build the test Docker image, exiting"
+    end
   end
 
   task :docker do
     unless system("docker version >/dev/null")
-      $stderr.puts "*** ERROR ***"
-      $stderr.puts "Docker is required to run the integration tests, but it is not available. Exiting"
-      $stderr.puts "*************"
-      exit 1
+      fail "Docker is required to run the integration tests, but it is not available. Exiting"
     end
+  end
+
+  def fail(msg)
+    $stderr.puts "*** ERROR ***"
+    $stderr.puts msg
+    $stderr.puts "*************"
+    exit 1
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,22 @@
 require "bundler/gem_tasks"
+
+namespace :test do
+  desc "Run the integration tests in a Docker container"
+  task :integration => :build_image do
+    exec "docker run -i -t discoverd-ruby-test"
+  end
+
+  desc "Build the Docker image for running tests"
+  task :build_image => :docker do
+    system "docker build -rm=true -t discoverd-ruby-test ."
+  end
+
+  task :docker do
+    unless system("docker version >/dev/null")
+      $stderr.puts "*** ERROR ***"
+      $stderr.puts "Docker is required to run the integration tests, but it is not available. Exiting"
+      $stderr.puts "*************"
+      exit 1
+    end
+  end
+end

--- a/discover.gemspec
+++ b/discover.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'yajl-ruby'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest", ">= 5.2.3"
 end

--- a/lib/discover.rb
+++ b/lib/discover.rb
@@ -13,6 +13,13 @@ module Discover
     end
 
     def register(name, port=nil, ip=nil)
+      args = {
+        "Name" => name,
+        "Addr" => "#{ip}:#{port}"
+      }
+
+      @client.request('Agent.Register', args)
+
       # spawn heartbeat actor
       # return Discover::Registration
     end

--- a/test/integration/test_registration.rb
+++ b/test/integration/test_registration.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class TestRegistration < Minitest::Test
+  def test_service_is_online_after_registration
+    client = Discover::Client.new
+
+    name = "foo"
+    port = 1111
+    ip   = "127.0.0.1"
+
+    client.register name, port, ip
+
+    service = client.service(name)
+
+    assert_equal 1, service.online.size
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,9 @@
+# Since both Celluloid and Minitest use at_exit hooks, we need to ensure
+# that the Minitest hook runs before the Celluloid one (so Celluloid has
+# not shutdown when the tests run), so we need to require Minitest *after*
+# Celluloid (as at_exit hooks are called in reverse order)
+require "discover"
+require "minitest/autorun"
+
+# Only log Celluloid errors
+Celluloid.logger.level = Logger::ERROR


### PR DESCRIPTION
This is just to get an opinion on this style of testing.

Running `rake spec:integration` will:
- check that Docker is accessible (I am using boot2docker on OSX)
- build a Docker image with etcd, discoverd, Ruby & gems
- run a container from the image which will run etcd and discoverd in the background, then run the integration specs

Thoughts?
