### PR TITLE
Keep registered services online until unregistered

### DIFF
--- a/lib/discover.rb
+++ b/lib/discover.rb
@@ -8,8 +8,12 @@ module Discover
       @client = RPCClient.new(host, port)
     end
 
+    def request(*args, &block)
+      @client.request(*args, &block)
+    end
+
     def service(name, filters={})
-      Service.new(@client, name, filters)
+      Service.new(self, name, filters)
     end
 
     def register(name, port=nil, ip=nil, attributes={})

--- a/lib/discover.rb
+++ b/lib/discover.rb
@@ -4,8 +4,11 @@ require 'yajl'
 
 module Discover
   class Client
+    include Celluloid
+
     def initialize(host='127.0.0.1', port=1111)
-      @client = RPCClient.new(host, port)
+      @client        = RPCClient.new(host, port)
+      @registrations = []
     end
 
     def request(*args, &block)
@@ -17,16 +20,75 @@ module Discover
     end
 
     def register(name, port=nil, ip=nil, attributes={})
+      reg = Registration.new(self, name, "#{ip}:#{port}", attributes)
+      @registrations << reg
+      reg.register
+      reg
+    end
+
+    def remove_registration(reg)
+      @registrations.delete(reg)
+    end
+
+    def unregister_all
+      @registrations.each(&:unregister)
+    end
+  end
+
+  class Registration
+    include Celluloid
+
+    HEARTBEAT_INTERVAL = 5
+
+    def initialize(client, name, address, attributes = {})
+      @client     = client
+      @name       = name
+      @address    = address
+      @attributes = attributes
+    end
+
+    def register
+      send_register_request
+      start_heartbeat
+    end
+
+    def unregister
+      stop_heartbeat
+      send_unregister_request
+      @client.remove_registration(self)
+    end
+
+    def send_register_request
       args = {
-        "Name"  => name,
-        "Addr"  => "#{ip}:#{port}",
-        "Attrs" => attributes
+        "Name"  => @name,
+        "Addr"  => @address,
+        "Attrs" => @attributes
       }
 
-      @client.request('Agent.Register', args)
+      @client.request("Agent.Register", args).value
+    end
 
-      # spawn heartbeat actor
-      # return Discover::Registration
+    def send_unregister_request
+      args = {
+        "Name"  => @name,
+        "Addr"  => @address
+      }
+
+      @client.request("Agent.Unregister", args).value
+    end
+
+    def start_heartbeat
+      @heartbeat = every(HEARTBEAT_INTERVAL) do
+        @client.request(
+          "Agent.Heartbeat",
+          "Name" => @name,
+          "Addr" => @address
+        )
+      end
+    end
+
+    def stop_heartbeat
+      @heartbeat.cancel
     end
   end
 
@@ -94,6 +156,10 @@ module Discover
     class Update < Struct.new(:address, :attributes, :name, :online)
       def self.from_hash(hash)
         new *hash.values_at("Addr", "Attrs", "Name", "Online")
+      end
+
+      def attributes
+        super || {}
       end
 
       def online?
@@ -184,11 +250,6 @@ module Discover
       @filters.all? do |key, val|
         update.attributes[key] == val
       end
-    end
-  end
-
-  class Registration
-    def destroy
     end
   end
 end

--- a/test/integration/test_registration.rb
+++ b/test/integration/test_registration.rb
@@ -17,6 +17,25 @@ class TestRegistration < DiscoverIntegrationTest
     assert_equal "#{ip}:#{port}", instance.address
     assert_equal attributes, instance.attributes
     assert instance.online?
+
+    sleep(11)
+    assert_equal 1, service.online.size
+  end
+
+  def test_service_is_offline_after_unregister
+    name       = "foo"
+    port       = 1111
+    ip         = "127.0.0.1"
+
+    registration = @client.register name, port, ip
+
+    service = @client.service(name)
+    assert_equal 1, service.online.size
+
+    registration.unregister
+
+    service = @client.service(name)
+    assert_equal 0, service.online.size
   end
 
   def test_changing_service_attributes

--- a/test/support/discover_integration_test.rb
+++ b/test/support/discover_integration_test.rb
@@ -13,6 +13,7 @@ class DiscoverIntegrationTest < Minitest::Test
   end
 
   def teardown
+    @client.unregister_all
     sleep(0.2)
     Process.kill("TERM", @discoverd_pid)
     Process.kill("TERM", @etcd_pid)


### PR DESCRIPTION
I'm not really happy with [this change](https://github.com/flynn/discoverd-ruby/blob/registration-updates/test/integration/test_registration.rb#L21) but I don't see another way of testing?
