### PR TITLE
Rename discoverd-ruby -> ruby-discoverd

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -39,10 +39,10 @@ RUN git clone -b master https://github.com/flynn/discoverd.git /go/src/github.co
     cd /go/src/github.com/flynn/discoverd && \
     /go/bin/godep go install
 
-# Add discoverd-ruby
-ADD . /discoverd-ruby
+# Add ruby-discoverd
+ADD . /ruby-discoverd
 
 # Bundle the gems (needs build tools)
 RUN apt-get install -y build-essential && \
     gem install --no-ri --no-rdoc bundler && \
-    bundle install --gemfile /discoverd-ruby/Gemfile
+    bundle install --gemfile /ruby-discoverd/Gemfile

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
-FROM discoverd-ruby-base
+FROM ruby-discoverd-base
 
-# Add discoverd-ruby
-ADD . /discoverd-ruby
+# Add ruby-discoverd
+ADD . /ruby-discoverd
 
 # Run etcd, discoverd then the integration tests
-CMD bash -c "cd /discoverd-ruby && PATH=\${PATH}:/go/bin bundle exec rake test:integration"
+CMD bash -c "cd /ruby-discoverd && PATH=\${PATH}:/go/bin bundle exec rake test:integration"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discover
 
-[![Build Status](https://travis-ci.org/flynn/discoverd-ruby.png?branch=master)](https://travis-ci.org/flynn/discoverd-ruby)
+[![Build Status](https://travis-ci.org/flynn/ruby-discoverd.png?branch=master)](https://travis-ci.org/flynn/ruby-discoverd)
 
 TODO: Write a gem description
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ namespace :test do
         command << %{-e "#{key}"="#{val}"}
       end
 
-      command << "discoverd-ruby-test"
+      command << "ruby-discoverd-test"
 
       exec command.join(" ")
     end
@@ -46,7 +46,7 @@ namespace :test do
     file "tmp/.build_base_image" => BASE_IMAGE_FILE_DEPENDENCIES do
       FileUtils.ln_sf "Dockerfile.base", "Dockerfile"
 
-      unless system "docker build -rm=true -t discoverd-ruby-base ."
+      unless system "docker build -rm=true -t ruby-discoverd-base ."
         fail "failed to build the test Docker image, exiting"
       end
 
@@ -58,7 +58,7 @@ namespace :test do
     task :build_test_image do
       FileUtils.ln_sf "Dockerfile.test", "Dockerfile"
 
-      unless system "docker build -rm=true -t discoverd-ruby-test ."
+      unless system "docker build -rm=true -t ruby-discoverd-test ."
         fail "failed to build the test Docker image, exiting"
       end
     end


### PR DESCRIPTION
We're calling all clients $LANG-$SERVICE for consistency.
